### PR TITLE
downgrade gulp-rev-all to a working version 0.8.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-plumber": "1.0.1",
     "gulp-protractor": "1.0.0",
     "gulp-rename": "1.2.2",
-    "gulp-rev-all": "0.8.21",
+    "gulp-rev-all": "0.8.18",
     "gulp-sass": "2.0.3",
     "gulp-size": "1.2.1",
     "gulp-streamify": "0.0.5",


### PR DESCRIPTION
gulp-rev-all commit https://github.com/smysnk/gulp-rev-all/commit/056baae48d458391f173c0a1b2e8740f954fa36b
is suspected to be the cause for a bug that gives this kind of error when loading a single-page-app:
Uncaught SyntaxError: Failed to execute 'querySelector' on 'Document': '[ng-app.72f7a5f6]' is not a valid selector.

For now, solve this by downgrading to a working version of gulp-rev-all.
